### PR TITLE
Multi cluster management

### DIFF
--- a/k8s_services_srv.py
+++ b/k8s_services_srv.py
@@ -10,6 +10,8 @@ import bz2
 
 # Global variable
 K8S_V1_CLIENT = client.CoreV1Api()
+# Constants
+R53_RETRY = 10
 
 
 def get_k8s_config():
@@ -204,8 +206,6 @@ def main(region, label_selector, namespace, srv_record, r53_zone_id):
         format='%(asctime)s - %(levelname)s - %(message)s', level=logging.INFO)
     global K8S_V1_CLIENT
 
-    R53_RETRY = 10
-
     try:
         get_k8s_config()
         K8S_V1_CLIENT = client.CoreV1Api()
@@ -237,7 +237,7 @@ def main(region, label_selector, namespace, srv_record, r53_zone_id):
             if all_dns_values == None:
                 logging.info("Waiting for {} seconds".format(t*t))
                 time.sleep(t*t)
-            if t == R53_RETRY:
+            if t >= R53_RETRY:
                 logging.error("Error getting r53 info, exiting")
                 exit(-1)
 
@@ -265,7 +265,7 @@ def main(region, label_selector, namespace, srv_record, r53_zone_id):
                 if updated == None:
                     logging.info("Waiting for {} seconds".format(t*t))
                     time.sleep(t*t)
-                if t == R53_RETRY:
+                if t >= R53_RETRY:
                     logging.error("Error updating r53 info, exiting")
                     exit(-1)
         else:

--- a/k8s_services_srv.py
+++ b/k8s_services_srv.py
@@ -3,7 +3,6 @@ import click
 from kubernetes import config as k8s_config, client, watch
 import logging
 import urllib3
-import urllib.request
 import json
 import base64
 import bz2


### PR DESCRIPTION
Allow the script running in multiple k8s clusters with the same DNS record using a TXT record to store every informations 

- Migrate from DNS call to TXT record
- Add a record structure for each k8s cluster
- Allow the DNS records creation when non existant
- Add base64 + bz2 fonctions to encode / decode values stored in TXT record
- Correct a bug if k8s service have no endpoint